### PR TITLE
README.md: direct Gitlab visitors to GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ These images are based on [this parent image](https://hub.docker.com/r/coqorg/ba
 
 See also the [docker-coq wiki](https://github.com/coq-community/docker-coq/wiki) for details about how to use these images.
 
+This repository is [mirrored on Gitlab](https://gitlab.com/coq-community/docker-coq), but [https://github.com/coq-community/docker-coq/issues] and [pull requests](https://github.com/coq-community/docker-coq/pulls) are tracked on GitHub.
+
 <!-- tags -->

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ These images are based on [this parent image](https://hub.docker.com/r/coqorg/ba
 
 See also the [docker-coq wiki](https://github.com/coq-community/docker-coq/wiki) for details about how to use these images.
 
-This repository is [mirrored on Gitlab](https://gitlab.com/coq-community/docker-coq), but [https://github.com/coq-community/docker-coq/issues] and [pull requests](https://github.com/coq-community/docker-coq/pulls) are tracked on GitHub.
+This repository is [mirrored on Gitlab](https://gitlab.com/coq-community/docker-coq), but [issues](https://github.com/coq-community/docker-coq/issues) and [pull requests](https://github.com/coq-community/docker-coq/pulls) are tracked on GitHub.
 
 <!-- tags -->


### PR DESCRIPTION
Ditto for pull requests.

Sent because I was confused about this for a day. Yes, I’m tired, why do you ask? :-)

This PR is pointless here, but should be useful because the code is mirrored to gitlab (but PRs there are disabled).