### PR TITLE
Bump coq 8.12 (8.12.0 => 8.12.1)

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -77,7 +77,7 @@ images:
   - matrix:
       # TODO: replace latest with 2 images (single-switch), merge tags
       base: ['latest']
-      coq: ['8.12.0', '8.11.2', '8.10.2', '8.9.1', '8.8.2']
+      coq: ['8.12.1', '8.11.2', '8.10.2', '8.9.1', '8.8.2']
     build:
       context: './coq'
       dockerfile: './dual/stable/Dockerfile'
@@ -90,7 +90,7 @@ images:
         - tag: 'latest'
           if:
             # TODO: Bump this version too:
-            - '{matrix[coq]} == "8.12.0"'
+            - '{matrix[coq]} == "8.12.1"'
             - '{matrix[base]} == "latest"'
         - tag: '{matrix[coq]}'
           if: '{matrix[base]} == "latest"'
@@ -98,7 +98,7 @@ images:
           if: '{matrix[base]} == "latest"'
   - matrix:
       base: ['4.09.1-flambda']
-      coq: ['8.12.0', '8.11.2', '8.10.2', '8.9.1', '8.8.2']
+      coq: ['8.12.1', '8.11.2', '8.10.2', '8.9.1', '8.8.2']
     build:
       context: './coq'
       dockerfile: './stable/Dockerfile'
@@ -111,7 +111,7 @@ images:
         - tag: 'latest-ocaml-{matrix[base][%.*-*]}-flambda'
           if:
             # TODO: Bump this version too:
-            - '{matrix[coq]} == "8.12.0"'
+            - '{matrix[coq]} == "8.12.1"'
             - '{matrix[base]} != "latest"'
         - tag: '{matrix[coq]}-ocaml-{matrix[base]}'
           if: '{matrix[base]} != "latest"'


### PR DESCRIPTION
Follow-up of https://github.com/ocaml/opam-repository/pull/17619

To be merged once `opam update default && opam show coq.8.12.1 && echo OK` succeeds.