### PR TITLE
fix: Add missing trigger for mathcomp/mathcomp-dev:coq-dev

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -16,6 +16,8 @@ images:
       after_deploy:
         - 'test -n "$DMC_ID" || { echo "Error: DMC_ID is void."; false; }'
         - 'curl -X POST -F token="$DMC_TOKEN" -F ref=master -F "variables[CRON_MODE]=rebuild-keyword" -F "variables[ITEM]=dev" https://gitlab.com/api/v4/projects/$DMC_ID/trigger/pipeline'
+        - 'test -n "$MC_ID" || { echo "Error: MC_ID is void."; false; }'
+        - 'curl -X POST -F token="$MC_TOKEN" -F ref=master -F "variables[CRON_MODE]=nightly" https://gitlab.com/api/v4/projects/$MC_ID/trigger/pipeline'
         # no 'if:' as the matrix is flat
       context: './coq'
       dockerfile: './dual/dev/Dockerfile'


### PR DESCRIPTION
Really Close: https://github.com/math-comp/math-comp/issues/681

(#18 was incomplete: only the mathcomp/mathcomp:latest-coq-dev trigger was setup before this patch)