### PR TITLE
feat: Release coqorg/coq:8.20-rc1

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -212,85 +212,54 @@ images:
       default: ['4.13.1-flambda']
       # only *-flambda switches
       base: ['4.14.2-flambda', '4.13.1-flambda', '4.12.1-flambda', '4.09.1-flambda']
-      # TODO: Bump to 8.20-rc1 when appropriate
-      coq: ['8.20-alpha']
+      coq: ['8.20-rc1']
     build: &build_coq_alpha
-      # TODO: Remove this commit_api section when the rc is tagged
-      commit_api:
-        fetcher: 'github'
-        repo: 'coq/coq'
-        branch: 'v8.20'
       context: './coq'
-      # TODO: Replace when the rc is tagged
-      dockerfile: './dev/Dockerfile'
-      # dockerfile: './beta/Dockerfile'
+      dockerfile: './beta/Dockerfile'
       keywords:
-        # TODO: replace when the rc is tagged
-        - '{matrix[coq][%-alpha]}'
-        # - '{matrix[coq][%-*]}'
+        - '{matrix[coq][%-*]}'
       args:
         BASE_TAG: '{matrix[base]}'
         COQ_VERSION: '{matrix[coq][//-/+]}'
-        # TODO: Remove COQ_COMMIT when the rc is tagged
-        COQ_COMMIT: '{defaults[commit]}'
-        # TODO: Replace when the rc is tagged
-        VCS_REF: '{defaults[commit][0:7]}'
-        # VCS_REF: 'V{matrix[coq][//-/+]}'
+        VCS_REF: 'V{matrix[coq][//-/+]}'
         COQ_EXTRA_OPAM: 'coq-bignums'
         # +- coq-native
-        # TODO: Replace when the rc is tagged
-        COQ_INSTALL_SERAPI: 'false'
-        # COQ_INSTALL_SERAPI: 'true'
+        COQ_INSTALL_SERAPI: 'true'
         # (or any nonempty string) as coq-serapi supports ocaml 4.07.1+
       tags:
         # full tag
         - tag: '{matrix[coq]}-ocaml-{matrix[base]}'
         # abbreviated tag (*-ocaml-4.13-flambda)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}-ocaml-{matrix[base][%.*-*]}-flambda'
-        # - tag: '{matrix[coq][%-*]}-ocaml-{matrix[base][%.*-*]}-flambda'
+        - tag: '{matrix[coq][%-*]}-ocaml-{matrix[base][%.*-*]}-flambda'
         # default tag (8.20-alpha)
         - tag: '{matrix[coq]}'
           if: '{matrix[base]} == {matrix[default]}'
         # abbreviated tag (8.20)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}'
-        # - tag: '{matrix[coq][%-*]}'
+        - tag: '{matrix[coq][%-*]}'
           if: '{matrix[base]} == {matrix[default]}'
   # coqorg/coq:8.20-alpha-native
   - matrix:
       default: ['4.13.1']
       base: ['4.13.1', '4.13.1-flambda']
-      # TODO: Bump to 8.20-rc1 when appropriate
-      coq: ['8.20-alpha']
+      coq: ['8.20-rc1']
     build:
       <<: *build_coq_alpha
       args:
         BASE_TAG: '{matrix[base]}'
         COQ_VERSION: '{matrix[coq][//-/+]}'
-        # TODO: Remove COQ_COMMIT when the rc is tagged
-        COQ_COMMIT: '{defaults[commit]}'
-        # TODO: Replace when the rc is tagged
-        VCS_REF: '{defaults[commit][0:7]}'
-        # VCS_REF: 'V{matrix[coq][//-/+]}'
+        VCS_REF: 'V{matrix[coq][//-/+]}'
         COQ_EXTRA_OPAM: 'coq-native coq-bignums'
         # +- coq-native
-        # TODO: Replace when the rc is tagged
-        COQ_INSTALL_SERAPI: 'false'
-        # COQ_INSTALL_SERAPI: 'true'
+        COQ_INSTALL_SERAPI: 'true'
         # (or any nonempty string) as coq-serapi supports ocaml 4.07.1+
       tags:
         # full tag
         - tag: '{matrix[coq]}-native-ocaml-{matrix[base]}'
         # abbreviated tag (*-ocaml-4.13)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}-native-ocaml-{matrix[base][%.*]}'
-        # - tag: '{matrix[coq][%-*]}-native-ocaml-{matrix[base][%.*]}'
+        - tag: '{matrix[coq][%-*]}-native-ocaml-{matrix[base][%.*]}'
           if: '{matrix[base]} == {matrix[default]}'
         # abbreviated tag (*-ocaml-4.13-flambda)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}-native-ocaml-{matrix[base][%.*-*]}-flambda'
-        # - tag: '{matrix[coq][%-*]}-native-ocaml-{matrix[base][%.*-*]}-flambda'
+        - tag: '{matrix[coq][%-*]}-native-ocaml-{matrix[base][%.*-*]}-flambda'
           if: '{matrix[base]} != {matrix[default]}' # -flambda
         # default tag (8.20-alpha-native)
         - tag: '{matrix[coq]}-native'
@@ -299,14 +268,10 @@ images:
         - tag: '{matrix[coq]}-native-flambda'
           if: '{matrix[base]} != {matrix[default]}' # -flambda
         # abbreviated tag (8.20-native)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}-native'
-        # - tag: '{matrix[coq][%-*]}-native'
+        - tag: '{matrix[coq][%-*]}-native'
           if: '{matrix[base]} == {matrix[default]}'
         # abbreviated tag (8.20-native-flambda)
-        # TODO: Replace when the rc is tagged
-        - tag: '{matrix[coq][%-alpha]}-native-flambda'
-        # - tag: '{matrix[coq][%-*]}-native-flambda'
+        - tag: '{matrix[coq][%-*]}-native-flambda'
           if: '{matrix[base]} != {matrix[default]}' # -flambda
   ################################################################
   ## coqorg/coq:latest


### PR DESCRIPTION
cf. @proux01's comment in https://github.com/coq/coq/issues/18882#issuecomment-2194824976

8.20-rc1 is now available in `core-dev`: https://github.com/coq/opam/pull/3058

bignums is already available in `extra-dev`: https://github.com/coq/opam/pull/3054

IINM, the last required ingredient before merging the PR is [coq-serapi](https://opam.ocaml.org/packages/coq-serapi/)